### PR TITLE
check /proc/[pid]/comm for name to recognize tcsh properly

### DIFF
--- a/lib/Shell/Guess.pm
+++ b/lib/Shell/Guess.pm
@@ -165,6 +165,15 @@ sub running_shell
   return __PACKAGE__->command_shell if $^O eq 'dos';
 
   my $shell = eval {
+    open(my $fh, '<', File::Spec->catfile('', 'proc', getppid, 'comm')) || die;
+    my $command_line = <$fh>;
+    die unless defined $command_line; # don't spew warnings if read failed
+    close $fh;
+    $command_line =~ s/\0.*$//;
+    _unixy_shells($command_line);
+  }
+
+  || eval {
     open(my $fh, '<', File::Spec->catfile('', 'proc', getppid, 'cmdline')) || die;
     my $command_line = <$fh>;
     die unless defined $command_line; # don't spew warnings if read failed


### PR DESCRIPTION
This is my entry for December in the Pull Request Challenge 2017.

It addresses the Linux part of the problem in #6. I am afraid I cannot really help with the Windows part as I don't have proper access to a Windows machine.

From http://man7.org/linux/man-pages/man5/proc.5.html

>       /proc/[pid]/comm (since Linux 2.6.33)
>              This file exposes the process's comm value—that is, the com‐
>              mand name associated with the process.

This might or might not work to find tcsh, but if it fails, we can still continue with the other methods.